### PR TITLE
cors 可以接受環境變數帶入參數

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const upload = new multer({
 })
 app.use(
   cors({
-    origin: 'http://localhost:3000',
+    origin: process.env.ALLOWED_ORIGIN,
     credentials: true,
   })
 )


### PR DESCRIPTION
以環境變數設定 CORS 的接受來源，未來部署就不用改到這份程式碼

用法說明：
在本地端 API 測試時，在 foodmap-backend 資料夾裡的 .env 新增一行 `ALLOWED_ORIGIN=http://localhost:3000`